### PR TITLE
added error handling for serpapi

### DIFF
--- a/src/agents/Component/ToolComponent.py
+++ b/src/agents/Component/ToolComponent.py
@@ -249,6 +249,8 @@ class WebSearchComponent(ToolComponent):
             "q": query,
             "api_key": api_key,
         }).get_dict()
+        if "error" in results.keys():
+           raise Exception(results["error"])
         """execute"""
         snippets = []
         if "answer_box_list" in results.keys():


### PR DESCRIPTION
I noticed that even when an invalid API key was provided for serpapi, no exception was raised. This led to unexpected agent behavior wherein the agent was treating the error message returned from serpapi as the results of a web search. 

To fix this, I added these lines of code to ensure an exception would be raised. The Google and Bing branches of the WebSearchComponent both already raise exceptions as a reaction to an invalid API key, so I think updating the serpapi branch to do the same is an appropriate choice.