### PR TITLE
Extending base_LLM to include Replicate functionality

### DIFF
--- a/examples/Single_Agent/chat_bot/config.json
+++ b/examples/Single_Agent/chat_bot/config.json
@@ -1,16 +1,19 @@
 {
   "config": {
-    "API_KEY": "API_KEY",
+    "API_KEY": "", 
+    "EMBED_API_KEY": "",
     "PROXY": "",
     "API_BASE": "",
+    "EMBED_API_BASE": "",
     "MAX_CHAT_HISTORY": "10",
     "User_Names": "[\"User\"]",
-    "TOP_K": "3"
+    "TOP_K": "3",
+    "Embed_Model": ""
   },
-  "LLM_type": "OpenAI",
+  "LLM_type": "Replicate",
   "LLM": {
     "temperature": 0.0,
-    "model": "gpt-3.5-turbo-16k-0613",
+    "model": "replicate/llama-2-70b-chat:2796ee9483c3fd7aa2e171d38f4ca12251a30609463dcfd4cd76703f22e96cdf",
     "log_path": "logs/god"
   },
   "root": "Response_state",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ protobuf
 psutil
 PyYAML
 Requests
+replicate
 selenium
 sentence_transformers
 setuptools

--- a/src/agents/LLM/base_LLM.py
+++ b/src/agents/LLM/base_LLM.py
@@ -125,6 +125,117 @@ class OpenAILLM(LLM):
             save_logs(self.log_path, messages, response.choices[0].message["content"])
             return response.choices[0].message["content"]
 
+class ReplicateLLM(LLM):
+    def __init__(self,**kwargs) -> None:
+        super().__init__()
+        self.MAX_CHAT_HISTORY = eval(
+            os.environ["MAX_CHAT_HISTORY"]) if "MAX_CHAT_HISTORY" in os.environ else 10
+        
+        self.model = kwargs["model"] if "model" in kwargs else "replicate/llama-2-70b-chat:2796ee9483c3fd7aa2e171d38f4ca12251a30609463dcfd4cd76703f22e96cdf"
+        self.temperature = kwargs["temperature"] if "temperature" in  kwargs else 0.3
+        self.log_path = kwargs["log_path"].replace("/",os.sep) if "log_path" in kwargs else "logs"
+    
+
+    def get_stream(self,response, log_path, messages):
+        ans = ""
+        for res in response:
+            if res:
+                r = (res.choices[0]["delta"].get("content")
+                    if res.choices[0]["delta"].get("content") else "")
+                ans += r
+                yield r
+        
+        save_logs(log_path, messages, ans)
+        
+        
+        
+    def get_response(self,
+                    chat_history,
+                    system_prompt,
+                    last_prompt=None,
+                    stream=False,
+                    functions=None,
+                    function_call="auto",
+                    WAIT_TIME=20,
+                    **kwargs):
+        """
+        return LLM's response 
+        """
+        litellm.api_key = os.environ["API_KEY"]
+        if "PROXY" in os.environ:
+            assert "http:" in os.environ["PROXY"] or "socks" in os.environ["PROXY"],"PROXY error,PROXY must be http or socks"
+            litellm.proxy = os.environ["PROXY"]
+        if "API_BASE" in os.environ:
+            litellm.api_base = os.environ["API_BASE"]
+        active_mode = True if ("ACTIVE_MODE" in os.environ and os.environ["ACTIVE_MODE"] == "0") else False
+        model = self.model
+        temperature = self.temperature
+        
+        
+        if active_mode:
+            system_prompt = system_prompt + "Please keep your reply as concise as possible.Try to control within 100 words as much as possible"
+
+        messages = [{
+            "role": "system",
+            "content": system_prompt
+        }] if system_prompt else []
+        
+        if chat_history:
+            if len(chat_history) >  self.MAX_CHAT_HISTORY:
+                chat_history = chat_history[- self.MAX_CHAT_HISTORY:]
+            if isinstance(chat_history[0],dict):
+                messages += chat_history
+            elif isinstance(chat_history[0],Memory):
+                messages += [memory.get_gpt_message("user") for memory in chat_history]
+        
+        
+
+        if last_prompt:
+            if active_mode:
+                last_prompt = last_prompt + "Please keep your reply as concise as possible.Try to control within 100 words as much as possible"
+            # messages += [{"role": "system", "content": f"{last_prompt}"}]
+            messages[-1]["content"] += last_prompt
+        
+
+        while True:
+            try:
+                if functions:
+                    response = litellm.completion(
+                        model=model,
+                        messages=messages,
+                        functions=functions,
+                        function_call=function_call,
+                        temperature=temperature,
+                        custom_llm_provider = "openai"
+                    )
+                else:
+                    response = litellm.completion(
+                        model=model,
+                        messages=messages,
+                        temperature=temperature,
+                        stream=stream,
+                        custom_llm_provider = "openai")
+                break
+            except Exception as e:
+                print(e)
+                if "maximum context length is" in str(e):
+                    if len(messages)>1:
+                        del messages[1]
+                    else:
+                        assert False, "exceed max length"
+                else:
+                    print(f"Please wait {WAIT_TIME} seconds and resend later ...")
+                    time.sleep(WAIT_TIME)
+
+        if functions:
+            save_logs(self.log_path, messages, response)
+            return response.choices[0].message
+        elif stream:
+            return self.get_stream(response, self.log_path, messages)
+        else:
+            save_logs(self.log_path, messages, response.choices[0].message["content"])
+            return response.choices[0].message["content"]
+
 
 def init_LLM(default_log_path,**kwargs):
     LLM_type = kwargs["LLM_type"] if "LLM_type" in kwargs else "OpenAI"
@@ -134,6 +245,12 @@ def init_LLM(default_log_path,**kwargs):
             OpenAILLM(**kwargs["LLM"])
             if "LLM" in kwargs
             else OpenAILLM(model = "gpt-3.5-turbo-16k-0613",temperature=0.3,log_path=log_path)
+        )
+    if LLM_type == "Replicate": 
+        LLM = (
+            OpenAILLM(**kwargs["LLM"])
+            if "LLM" in kwargs
+            else OpenAILLM(model = "replicate/llama-2-70b-chat:2796ee9483c3fd7aa2e171d38f4ca12251a30609463dcfd4cd76703f22e96cdf",temperature=0.3,log_path=log_path)
         )
         return LLM
     

--- a/src/agents/utils.py
+++ b/src/agents/utils.py
@@ -68,7 +68,7 @@ def get_embedding(sentence):
                 "http:" in os.environ["PROXY"] or "socks" in os.environ["PROXY"]
             ), "PROXY error,PROXY must be http or socks"
             client.proxies = {os.environ["PROXY"]}
-        if "EMBED_API_BASE" in os.environ:
+        if "EMBED_API_BASE" in os.environ or "EMBED_BASE" in os.environ:
             client.base_url = (
         os.environ["EMBED_API_BASE"]
         if "EMBED_API_BASE" in os.environ

--- a/src/agents/utils.py
+++ b/src/agents/utils.py
@@ -32,6 +32,8 @@ import random
 import os
 import openai
 from openai import OpenAI
+import replicate
+
 
 is_load = False
 embedding_model = None
@@ -56,14 +58,22 @@ def get_embedding(sentence):
             )
 
     if embed_model_name in ["text-embedding-ada-002"]:
-        client = OpenAI(api_key=os.environ["API_KEY"])
+        client = OpenAI(api_key=(
+        os.environ["EMBED_API_KEY"]
+        if "EMBED_API_KEY" in os.environ
+        else os.environ["API_KEY"]
+    ))
         if "PROXY" in os.environ:
             assert (
                 "http:" in os.environ["PROXY"] or "socks" in os.environ["PROXY"]
             ), "PROXY error,PROXY must be http or socks"
             client.proxies = {os.environ["PROXY"]}
-        if "API_BASE" in os.environ:
-            client.base_url = os.environ["API_BASE"]
+        if "EMBED_API_BASE" in os.environ:
+            client.base_url = (
+        os.environ["EMBED_API_BASE"]
+        if "EMBED_API_BASE" in os.environ
+        else os.environ["API_BASE"]
+    )
         sentence = sentence.replace("\n", " ")
         embed = client.embeddings.create(input = sentence, model= embed_model_name,encoding_format="float").data[0].embedding
         embed = torch.tensor(embed, dtype=torch.float32)


### PR DESCRIPTION
Extended Base_LLM to be compatible with Replicate models, which can be accessed if the user specifies to use such model through LLM_type. Adjusted utils.py to include a separate EMBED_API and EMBED_API_BASE if two separate models are to be used. An example is shown in a modified version of chat_bot. 

